### PR TITLE
refactor services/population.js

### DIFF
--- a/src/services/population.js
+++ b/src/services/population.js
@@ -3,17 +3,19 @@
 import axios from 'axios';
 
 const API_KEY = import.meta.env.VITE_API_KEY;
+const header = {
+    'x-rapidapi-key': API_KEY,
+    'x-rapidapi-host': 'population-density-data.nokia.rapidapi.com',
+    'Content-Type': 'application/json'
+}
+
 console.log("myAPI_KEY",API_KEY);
 
 const get_population = async (boundaryArray, startDate, endDate, precision) => {
     const options = {
     method: 'POST',
     url: 'https://population-density-data.p-eu.rapidapi.com/retrieve',
-    headers: {
-    'x-rapidapi-key': '8415751a7amsh788117af31b3b0ap134484jsnba2161137f74',
-    'x-rapidapi-host': 'population-density-data.nokia.rapidapi.com',
-    'Content-Type': 'application/json'
-    },
+    headers: header,
     data: {
     area: {
         areaType: 'POLYGON',


### PR DESCRIPTION
This pull request includes changes to `src/services/population.js` to improve the handling of API headers by externalizing the header configuration and removing hardcoded values.

Improvements to API header handling:

* Added a `header` constant to store API headers, which includes the API key, host, and content type. This change externalizes the header configuration and removes hardcoded values from the `get_population` function.
* Updated the `headers` property in the `options` object within the `get_population` function to use the newly created `header` constant.